### PR TITLE
Add Ghostty theme definitions

### DIFF
--- a/ghostty/newt-dark-bright.conf
+++ b/ghostty/newt-dark-bright.conf
@@ -1,0 +1,23 @@
+# Newt dark bright theme for Ghostty
+palette = 0=#3e5262
+palette = 1=#db6150
+palette = 2=#6eb572
+palette = 3=#e1c167
+palette = 4=#5cacea
+palette = 5=#cd7ee1
+palette = 6=#79d8dc
+palette = 7=#e2ecf4
+palette = 8=#2f3a42
+palette = 9=#ab4c3f
+palette = 10=#61a065
+palette = 11=#bca257
+palette = 12=#628bab
+palette = 13=#b570c6
+palette = 14=#70c4c7
+palette = 15=#d9e2e8
+background = 3e5262
+foreground = e2ecf4
+cursor-color = 79d8dc
+cursor-text = 3e5262
+selection-background = 5088b4
+selection-foreground = e2ecf4

--- a/ghostty/newt-dark-normal.conf
+++ b/ghostty/newt-dark-normal.conf
@@ -1,0 +1,23 @@
+# Newt dark normal theme for Ghostty
+palette = 0=#2f3a42
+palette = 1=#ab4c3f
+palette = 2=#61a065
+palette = 3=#bca257
+palette = 4=#628bab
+palette = 5=#b570c6
+palette = 6=#70c4c7
+palette = 7=#d9e2e8
+palette = 8=#3e5262
+palette = 9=#db6150
+palette = 10=#6eb572
+palette = 11=#e1c167
+palette = 12=#5cacea
+palette = 13=#cd7ee1
+palette = 14=#79d8dc
+palette = 15=#e2ecf4
+background = 2f3a42
+foreground = d9e2e8
+cursor-color = 70c4c7
+cursor-text = 2f3a42
+selection-background = 4e6b81
+selection-foreground = d9e2e8

--- a/ghostty/newt-light-bright.conf
+++ b/ghostty/newt-light-bright.conf
@@ -1,0 +1,23 @@
+# Newt light bright theme for Ghostty
+palette = 0=#546468
+palette = 1=#d17360
+palette = 2=#88bc83
+palette = 3=#e0c97e
+palette = 4=#61a0dc
+palette = 5=#c88ce0
+palette = 6=#92dfe3
+palette = 7=#dae1e6
+palette = 8=#2f383f
+palette = 9=#a85b4c
+palette = 10=#7aa976
+palette = 11=#c0ad6c
+palette = 12=#6084a5
+palette = 13=#a368b9
+palette = 14=#80c4c8
+palette = 15=#c2c8cc
+background = c2c8cc
+foreground = 546468
+cursor-color = 92dfe3
+cursor-text = c2c8cc
+selection-background = a0bad2
+selection-foreground = 546468

--- a/ghostty/newt-light-normal.conf
+++ b/ghostty/newt-light-normal.conf
@@ -1,0 +1,23 @@
+# Newt light normal theme for Ghostty
+palette = 0=#2f383f
+palette = 1=#a85b4c
+palette = 2=#7aa976
+palette = 3=#c0ad6c
+palette = 4=#6084a5
+palette = 5=#a368b9
+palette = 6=#80c4c8
+palette = 7=#c2c8cc
+palette = 8=#546468
+palette = 9=#d17360
+palette = 10=#88bc83
+palette = 11=#e0c97e
+palette = 12=#61a0dc
+palette = 13=#c88ce0
+palette = 14=#92dfe3
+palette = 15=#dae1e6
+background = dae1e6
+foreground = 2f383f
+cursor-color = 80c4c8
+cursor-text = dae1e6
+selection-background = afc0cf
+selection-foreground = 2f383f


### PR DESCRIPTION
## Summary
- add Ghostty theme files for Newt dark/light variants covering normal and bright palettes

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e7610f4d1883218878061111edf5c1